### PR TITLE
feat: use gateway CAR

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,10 +21,9 @@ function fetchIPFS ({ cid, path, archive, compress }) {
 }
 
 async function fetchHTTP ({ api, cid, timeout: timeoutMs, path, archive, compress, spinner }) {
-  // TODO: replace /api/v0/export with gateway-native primitive after CAR support is added (https://github.com/ipfs/go-ipfs/issues/8234)
-  const url = `${api}/api/v0/dag/export?arg=${cid}`
+  const url = `${api}/ipfs/${cid}?format=car`
   const controller = new AbortController()
-  const fetchPromise = fetch(url, { signal: controller.signal, method: 'POST' })
+  const fetchPromise = fetch(url, { signal: controller.signal, method: 'GET' })
   const abort = () => controller.abort()
   let timeout = setTimeout(abort, timeoutMs)
 


### PR DESCRIPTION
Closes #34 and replaces the old `v0` API by the newly available gateway CARs.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>