### PR TITLE
breaking: rename option 'api' to 'gateway'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Usage
 
 ```
-npx ipfs-or-gateway -c cid -p path [--clean --archive --compress -a apiUrl]
+npx ipfs-or-gateway -c cid -p path [--clean --archive --compress -g gatewayUrl]
 ```
 
 - `--clean` – remove destination if it already exists

--- a/bin/index.js
+++ b/bin/index.js
@@ -28,8 +28,8 @@ const argv = yargs
     describe: 'compress the archive with GZIP compression',
     type: 'boolean',
     default: false
-  }).option('api', {
-    alias: 'a',
+  }).option('gateway', {
+    alias: 'g',
     describe: 'HTTP Gateway used for CAR export',
     type: 'string',
     default: 'https://ipfs.io'

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,8 +20,8 @@ function fetchIPFS ({ cid, path, archive, compress }) {
   })
 }
 
-async function fetchHTTP ({ api, cid, timeout: timeoutMs, path, archive, compress, spinner }) {
-  const url = `${api}/ipfs/${cid}?format=car`
+async function fetchHTTP ({ gateway, cid, timeout: timeoutMs, path, archive, compress, spinner }) {
+  const url = `${gateway}/ipfs/${cid}?format=car`
   const controller = new AbortController()
   const fetchPromise = fetch(url, { signal: controller.signal, method: 'GET' })
   const abort = () => controller.abort()
@@ -40,7 +40,7 @@ async function fetchHTTP ({ api, cid, timeout: timeoutMs, path, archive, compres
       timeout = setTimeout(abort, timeoutMs)
 
       if (spinner) {
-        spinner.start(`Fetching a verifiable CAR from ${api}: ${prettyBytes(p.done)}`)
+        spinner.start(`Fetching a verifiable CAR from ${gateway}: ${prettyBytes(p.done)}`)
       }
     })
 
@@ -64,7 +64,7 @@ async function fetchHTTP ({ api, cid, timeout: timeoutMs, path, archive, compres
   }
 }
 
-module.exports = async ({ cid, path, clean, archive, compress, verbose, timeout, api, retries }) => {
+module.exports = async ({ cid, path, clean, archive, compress, verbose, timeout, gateway, retries }) => {
   if (!cid || !path) {
     throw new Error('cid and path must be defined')
   }
@@ -106,7 +106,7 @@ module.exports = async ({ cid, path, clean, archive, compress, verbose, timeout,
     spinner.start(`Fetching via IPFS HTTP gateway (attempt ${i})…`)
 
     try {
-      await fetchHTTP({ cid, path, archive, compress, timeout, api, verbose, spinner })
+      await fetchHTTP({ cid, path, archive, compress, timeout, gateway, verbose, spinner })
       spinner.succeed(`Fetched ${cid} to ${path}!`)
       return
     } catch (e) {


### PR DESCRIPTION
The option `api` should be, in fact, `gateway`. We expect a Gateway URL and not an API URL. This PR changes that and it's a breaking change.